### PR TITLE
Fix for CVE-2018-10903 - Update python-cryptograpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==6.7
-cryptography==2.0.3
+cryptography==2.3.1
 setuptools==18.2
 pytest==3.2.2


### PR DESCRIPTION
Fix for CVE-2018-10903 - Update python-cryptograpy to version 2.3.1