### PR TITLE
Adds per node certificate support to generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,15 @@ Usage: exhibitor-tls-artifacts [OPTIONS] [NODES]...
   https://docs.mesosphere.com/1.13/security/ent/tls-ssl/exhibitor-tls/
 
 Options:
-  -d, --dir TEXT  Directory to put artifacts in.
+  -d, --output-directory TEXT  Directory to put artifacts in.
   --help          Show this message and exit.
 ```
 
 ## Artifact Usage
 
-All artifacts are found in `./artifacts/node_IP` or in the user specified directory.
+All artifacts are found in `./artifacts` or in the user specified directory. This
+tool creates sub-directories for each `NODE`. If the node ip address is `10.10.10.10`,
+the artifacts for that node will land in `<artifacts_dir>/node_10_10_10_10/`.
 
 * `clientstore.jks`
     * Contains `client-cert.pem` and `client-key.pem`.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ Usage: exhibitor-tls-artifacts [OPTIONS] [NODES]...
   https://docs.mesosphere.com/1.13/security/ent/tls-ssl/exhibitor-tls/
 
 Options:
-  -d, --output-directory TEXT  Directory to put artifacts in.
-  --help          Show this message and exit.
+  -d, --output-directory TEXT  Directory to put artifacts in. This
+                               output_directory must not exist.
+  --help                       Show this message and exit.
 ```
 
 ## Artifact Usage

--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ Using absolute path will result in artifacts being generated in the container an
 ## Script Usage
 
 ```sh
-Usage: exhibitor-tls-artifacts [OPTIONS]
+Usage: exhibitor-tls-artifacts [OPTIONS] [NODES]...
+
+  Generates Admin Router and Exhibitor TLS artifacts. NODES should consist
+  of a space seperated list of master ip addresses. See
+  https://docs.mesosphere.com/1.13/security/ent/tls-ssl/exhibitor-tls/
 
 Options:
-  --nodes TEXT    Comma separated list of master node ip addresses.
   -d, --dir TEXT  Directory to put artifacts in.
   --help          Show this message and exit.
-
 ```
 
 ## Artifact Usage

--- a/README.md
+++ b/README.md
@@ -69,20 +69,18 @@ Using absolute path will result in artifacts being generated in the container an
 ## Script Usage
 
 ```sh
-exhibitor-tls-artifacts [OPTIONS] [SANS]...
+Usage: exhibitor-tls-artifacts [OPTIONS]
 
-Args:
-    SANS: Subject Alternative Names to be put in the end-entity
-              certificates. Can be DNS names or IP addresses.
 Options:
-  -d, --dir TEXT  Directory to put generated artifacts in.
-                  Default: ./artifacts/ .
+  --nodes TEXT    Comma separated list of master node ip addresses.
+  -d, --dir TEXT  Directory to put artifacts in.
   --help          Show this message and exit.
+
 ```
 
 ## Artifact Usage
 
-All artifacts are found in `./artifacts/` or in the user specified directory.
+All artifacts are found in `./artifacts/node_IP` or in the user specified directory.
 
 * `clientstore.jks`
     * Contains `client-cert.pem` and `client-key.pem`.

--- a/exhibitor_tls_artifacts/gen_artifacts.py
+++ b/exhibitor_tls_artifacts/gen_artifacts.py
@@ -7,7 +7,7 @@ from .gen_stores import KeystoreGenerator
 from .validators import validate_dir_missing
 
 
-@click.command()
+@click.command(name='exhibitor-tls-artifacts')
 @click.argument('nodes', nargs=-1)
 @click.option(
     '-d',
@@ -18,7 +18,7 @@ from .validators import validate_dir_missing
 def app(nodes, output_directory):
     """
     Generates Admin Router and Exhibitor TLS artifacts. NODES should consist
-    of a space seperated list of master ip addresses. See
+    of a space separated list of master ip addresses. See
     https://docs.mesosphere.com/1.13/security/ent/tls-ssl/exhibitor-tls/
     """
     if not nodes:

--- a/exhibitor_tls_artifacts/gen_artifacts.py
+++ b/exhibitor_tls_artifacts/gen_artifacts.py
@@ -9,19 +9,26 @@ from .gen_stores import KeystoreGenerator
 
 
 @click.command()
-@click.option('--nodes', help='Comma separated list of master node ip addresses.', required=True)
+@click.argument('nodes', nargs=-1)
 @click.option('-d', '--dir', help='Directory to put artifacts in.',
               default='./artifacts/')
 def app(nodes, dir):
+    """
+    Generates Admin Router and Exhibitor TLS artifacts. NODES should consist
+    of a space seperated list of master ip addresses. See
+    https://docs.mesosphere.com/1.13/security/ent/tls-ssl/exhibitor-tls/
+    """
     dir = Path(dir)
     if dir.exists():
-        print('{} already exists'.format(dir))
+        print('{} already exists.'.format(dir))
+        sys.exit(1)
+
+    if not nodes:
+        print('No nodes have been provided.')
         sys.exit(1)
 
     # Create artifact directory
     os.makedirs(dir)
-
-    nodes = nodes.split(',')
 
     # Admin router (nginx) requires `exhibitor` to exist as a SAN on all nodes
     # due to peculiarity in the nginx TLS client.

--- a/exhibitor_tls_artifacts/gen_artifacts.py
+++ b/exhibitor_tls_artifacts/gen_artifacts.py
@@ -1,11 +1,10 @@
 import click
 import os
 import shutil
-import sys
-from pathlib import Path
 
 from .gen_certificates import CertificateGenerator
 from .gen_stores import KeystoreGenerator
+from .validators import validate_dir_missing
 
 
 @click.command()
@@ -14,18 +13,14 @@ from .gen_stores import KeystoreGenerator
     '-d',
     '--output-directory',
     help='Directory to put artifacts in. This output_directory must not exist.',
-    default='./artifacts/')
+    default='./artifacts/',
+    callback=validate_dir_missing)
 def app(nodes, output_directory):
     """
     Generates Admin Router and Exhibitor TLS artifacts. NODES should consist
     of a space seperated list of master ip addresses. See
     https://docs.mesosphere.com/1.13/security/ent/tls-ssl/exhibitor-tls/
     """
-    output_directory = Path(output_directory)
-    if output_directory.exists():
-        raise click.BadOptionUsage(
-            message='{} already exists.'.format(output_directory))
-
     if not nodes:
         raise click.BadArgumentUsage('No nodes have been provided.')
 

--- a/exhibitor_tls_artifacts/gen_artifacts.py
+++ b/exhibitor_tls_artifacts/gen_artifacts.py
@@ -10,9 +10,11 @@ from .gen_stores import KeystoreGenerator
 
 @click.command()
 @click.argument('nodes', nargs=-1)
-@click.option('-d', '--output-directory',
-              help='Directory to put artifacts in. This output_directory must not exist.',
-              default='./artifacts/')
+@click.option(
+    '-d',
+    '--output-directory',
+    help='Directory to put artifacts in. This output_directory must not exist.',
+    default='./artifacts/')
 def app(nodes, output_directory):
     """
     Generates Admin Router and Exhibitor TLS artifacts. NODES should consist
@@ -47,18 +49,24 @@ def app(nodes, output_directory):
         for node in nodes:
             node_path_name = 'node_' + node.replace('.', '_')
             client_cert_path, client_key_path = cert_generator.get_cert(
-                cert_name='client', node_cert_path=node_path_name, issuer=(root_cert_path, root_key_path),
+                cert_name='client',
+                node_cert_path=node_path_name,
+                issuer=(root_cert_path, root_key_path),
                 sa_names=sans + [node])
             server_cert_path, server_key_path = cert_generator.get_cert(
-                cert_name='server', node_cert_path=node_path_name, issuer=(root_cert_path, root_key_path),
+                cert_name='server',
+                node_cert_path=node_path_name,
+                issuer=(root_cert_path, root_key_path),
                 sa_names=sans + [node])
 
             store_generator.create_entitystore(client_cert_path,
                                                client_key_path,
-                                               store_name='clientstore', node_cert_path=node_path_name)
+                                               store_name='clientstore',
+                                               node_cert_path=node_path_name)
             store_generator.create_entitystore(server_cert_path,
                                                server_key_path,
-                                               store_name='serverstore', node_cert_path=node_path_name)
+                                               store_name='serverstore',
+                                               node_cert_path=node_path_name)
             os.remove(server_cert_path)
             os.remove(server_key_path)
 

--- a/exhibitor_tls_artifacts/gen_certificates.py
+++ b/exhibitor_tls_artifacts/gen_certificates.py
@@ -17,8 +17,12 @@ class CertificateGenerator:
     Generate `x509` certificates in `pem` format.
     """
 
-    def __init__(self, artifact_dir, country='US', state='CA',
-                 locality='San Francisco', organization='Mesosphere'):
+    def __init__(self,
+                 artifact_dir,
+                 country='US',
+                 state='CA',
+                 locality='San Francisco',
+                 organization='Mesosphere'):
         # This adds trailing / to the path
         self.artifact_dir = os.path.join(artifact_dir, '')
         self.country = country
@@ -29,10 +33,7 @@ class CertificateGenerator:
     def load_cert(self, cert_path):
         with open(cert_path, "rb") as f:
             cert_data = f.read()
-            cert = x509.load_pem_x509_certificate(
-                cert_data,
-                default_backend()
-            )
+            cert = x509.load_pem_x509_certificate(cert_data, default_backend())
 
         return cert
 
@@ -44,11 +45,9 @@ class CertificateGenerator:
     def load_key(self, key_path, password=None):
         with open(key_path, "rb") as f:
             key_data = f.read()
-            key = serialization.load_pem_private_key(
-                data=bytes(key_data),
-                password=password,
-                backend=default_backend()
-            )
+            key = serialization.load_pem_private_key(data=bytes(key_data),
+                                                     password=password,
+                                                     backend=default_backend())
 
         return key
 
@@ -60,15 +59,19 @@ class CertificateGenerator:
             encryption = serialization.BestAvailableEncryption(password)
 
         with open(key_path, 'wb') as f:
-            f.write(key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=encryption
-            ))
+            f.write(
+                key.private_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PrivateFormat.TraditionalOpenSSL,
+                    encryption_algorithm=encryption))
 
         os.chmod(key_path, 0o600)
 
-    def get_cert(self, cert_name='entity', node_cert_path='', key_pass=None, sa_names=None,
+    def get_cert(self,
+                 cert_name='entity',
+                 node_cert_path='',
+                 key_pass=None,
+                 sa_names=None,
                  issuer=None):
         """
         Creates self signed CA certificates or end-entity certificates.
@@ -95,11 +98,9 @@ class CertificateGenerator:
         cert_path = base_path / cert_file
         key_path = base_path / key_file
 
-        cert_key = rsa.generate_private_key(
-            public_exponent=65537,
-            key_size=4096,
-            backend=default_backend()
-        )
+        cert_key = rsa.generate_private_key(public_exponent=65537,
+                                            key_size=4096,
+                                            backend=default_backend())
 
         self.__store_key(cert_key, key_path, key_pass)
 
@@ -118,25 +119,18 @@ class CertificateGenerator:
             issuer_cert = self.load_cert(issuer[0])
             cert_issuer_subject = issuer_cert.subject
             issuer_key = self.load_key(issuer[1],
-                                       issuer[2] if len(issuer) > 2
-                                       else None)
+                                       issuer[2] if len(issuer) > 2 else None)
         else:
             cert_issuer_subject = cert_subject
             issuer_key = cert_key
 
-        cert = x509.CertificateBuilder().subject_name(
-            cert_subject
-        ).issuer_name(
-            cert_issuer_subject
-        ).public_key(
-            cert_key.public_key()
-        ).serial_number(
-            x509.random_serial_number()
-        ).not_valid_before(
-            datetime.datetime.utcnow()
-        ).not_valid_after(
-            datetime.datetime.utcnow() + datetime.timedelta(days=10 * 365)
-        )
+        cert = x509.CertificateBuilder().subject_name(cert_subject).issuer_name(
+            cert_issuer_subject).public_key(
+                cert_key.public_key()).serial_number(
+                    x509.random_serial_number()).not_valid_before(
+                        datetime.datetime.utcnow()).not_valid_after(
+                            datetime.datetime.utcnow() +
+                            datetime.timedelta(days=10 * 365))
 
         cert = cert.add_extension(
             x509.BasicConstraints(ca=True if issuer is None else False,
@@ -148,10 +142,7 @@ class CertificateGenerator:
         for name in sa_names:
             try:
                 converted_names.append(
-                    x509.IPAddress(
-                        ipaddress.ip_address(name)
-                    )
-                )
+                    x509.IPAddress(ipaddress.ip_address(name)))
             except ValueError:
                 converted_names.append(x509.DNSName(name))
 

--- a/exhibitor_tls_artifacts/gen_certificates.py
+++ b/exhibitor_tls_artifacts/gen_certificates.py
@@ -38,7 +38,7 @@ class CertificateGenerator:
         return cert
 
     def __store_cert(self, cert, cert_path):
-        os.makedirs(cert_path.parent, mode=0o700, exist_ok=True)
+        cert_path.parent.mkdir(mode=0o700, exist_ok=True)
         with open(cert_path, 'wb') as f:
             f.write(cert.public_bytes(serialization.Encoding.PEM))
 
@@ -52,7 +52,7 @@ class CertificateGenerator:
         return key
 
     def __store_key(self, key, key_path, password=None):
-        os.makedirs(key_path.parent, mode=0o700, exist_ok=True)
+        key_path.parent.mkdir(mode=0o700, exist_ok=True)
         if password is None:
             encryption = serialization.NoEncryption()
         else:

--- a/exhibitor_tls_artifacts/gen_stores.py
+++ b/exhibitor_tls_artifacts/gen_stores.py
@@ -166,5 +166,5 @@ class KeystoreGenerator:
                 ' '.join(pkcs12_cmd)
             ))
 
-        os.chmod(java_store_path, 0o600)
+        java_store_path.chmod(0o600)
         return java_store_path

--- a/exhibitor_tls_artifacts/gen_stores.py
+++ b/exhibitor_tls_artifacts/gen_stores.py
@@ -16,7 +16,9 @@ class KeystoreGenerator:
         # Directory where the artifacts, certificates are stored.
         self.artifact_dir = os.path.join(artifact_dir, '')
 
-    def create_truststore(self, trusted_cert_paths, name='truststore',
+    def create_truststore(self,
+                          trusted_cert_paths,
+                          name='truststore',
                           password='not-relevant-for-security'):
         """
         Generate `jks` truststore.
@@ -36,17 +38,9 @@ class KeystoreGenerator:
         for cert_path in trusted_cert_paths:
             alias = os.path.splitext(os.path.basename(cert_path))[0]
             cmd = [
-                'keytool',
-                '-keystore',
-                str(store_path),
-                '-import',
-                '-alias',
-                alias,
-                '-file',
-                str(cert_path),
-                '-trustcacerts',
-                '-storepass',
-                password,
+                'keytool', '-keystore',
+                str(store_path), '-import', '-alias', alias, '-file',
+                str(cert_path), '-trustcacerts', '-storepass', password,
                 '-noprompt'
             ]
 
@@ -54,15 +48,16 @@ class KeystoreGenerator:
             proc = Popen(cmd, shell=False, stderr=PIPE, stdout=PIPE)
             stdout, stderr = proc.communicate()
             if proc.wait() != 0:
-                raise Exception('{}{}'.format(
-                    stdout.decode(),
-                    stderr.decode()
-                ))
+                raise Exception('{}{}'.format(stdout.decode(), stderr.decode()))
 
         os.chmod(store_path, 0o600)
         return store_path
 
-    def create_entitystore(self, cert_path, key_path, node_cert_path='', chain=False,
+    def create_entitystore(self,
+                           cert_path,
+                           key_path,
+                           node_cert_path='',
+                           chain=False,
                            store_name='entitystore',
                            store_password='not-relevant-for-security'):
         """
@@ -93,78 +88,45 @@ class KeystoreGenerator:
         certificate_alias = cert_path.name.split('.')[0]
 
         pkcs12_cmd = [
-            'openssl',
-            'pkcs12',
-            '-export',
-            '-in',
-            str(cert_path),
-            '-inkey',
-            str(key_path),
-            '-out',
-            str(pkcs12_store_path),
-            '-name',
-            certificate_alias,
-            '-passout',
+            'openssl', 'pkcs12', '-export', '-in',
+            str(cert_path), '-inkey',
+            str(key_path), '-out',
+            str(pkcs12_store_path), '-name', certificate_alias, '-passout',
             'pass:' + store_password
         ]
 
         if chain:
-            pkcs12_cmd.extend([
-                '-CAfile',
-                str(cert_path),
-                '-chain'
-            ])
+            pkcs12_cmd.extend(['-CAfile', str(cert_path), '-chain'])
 
         log.info('Creating pkcs12 {} keystore: {}'.format(
-            store_name,
-            ' '.join(pkcs12_cmd)
-        ))
+            store_name, ' '.join(pkcs12_cmd)))
 
         proc = Popen(pkcs12_cmd, shell=False, stdout=PIPE, stderr=PIPE)
         stdout, stderr = proc.communicate()
         if proc.wait() != 0:
-            raise Exception('{}{}'.format(
-                stdout.decode(),
-                stderr.decode()
-            ))
+            raise Exception('{}{}'.format(stdout.decode(), stderr.decode()))
 
         keystore_cmd = [
-            'keytool',
-            '-importkeystore',
-            '-destkeystore',
-            str(java_store_path),
-            '-srckeystore',
-            str(pkcs12_store_path),
-            '-srcstoretype',
-            'pkcs12',
-            '-alias',
-            certificate_alias,
-            '-srcstorepass',
-            store_password,
-            '-deststorepass',
-            store_password,
-            '-noprompt'
+            'keytool', '-importkeystore', '-destkeystore',
+            str(java_store_path), '-srckeystore',
+            str(pkcs12_store_path), '-srcstoretype', 'pkcs12', '-alias',
+            certificate_alias, '-srcstorepass', store_password,
+            '-deststorepass', store_password, '-noprompt'
         ]
 
-        log.info('Creating jks {} keystore: {}'.format(
-            store_name,
-            ' '.join(pkcs12_cmd)))
+        log.info('Creating jks {} keystore: {}'.format(store_name,
+                                                       ' '.join(pkcs12_cmd)))
 
         proc = Popen(keystore_cmd, shell=False, stdout=PIPE, stderr=PIPE)
         stdout, stderr = proc.communicate()
         if proc.wait() != 0:
-            raise Exception('{}{}'.format(
-                stdout.decode(),
-                stderr.decode()
-            ))
+            raise Exception('{}{}'.format(stdout.decode(), stderr.decode()))
 
         try:
             os.remove(pkcs12_store_path)
         except OSError:
             log.error('Could not remove pcks12 {} keystore: {}'.format(
-                store_name,
-                ' '.join(pkcs12_cmd)
-            ))
+                store_name, ' '.join(pkcs12_cmd)))
 
         java_store_path.chmod(0o600)
         return java_store_path

--- a/exhibitor_tls_artifacts/validators.py
+++ b/exhibitor_tls_artifacts/validators.py
@@ -1,0 +1,12 @@
+import click
+from pathlib import Path
+
+
+def validate_dir_missing(ctx, param, value):
+    """ click validator to ensure that artifacts directory does not exist """
+    path = Path(value)
+
+    if path.exists():
+        raise click.BadParameter(message="Artifacts directory cannot exist!")
+
+    return path

--- a/exhibitor_tls_artifacts/validators.py
+++ b/exhibitor_tls_artifacts/validators.py
@@ -7,6 +7,6 @@ def validate_dir_missing(ctx, param, value):
     path = Path(value)
 
     if path.exists():
-        raise click.BadParameter(message="Artifacts directory cannot exist!")
+        raise click.BadParameter(message="Artifacts directory {} already exists.".format(value))
 
     return path

--- a/exhibitor_tls_artifacts/validators.py
+++ b/exhibitor_tls_artifacts/validators.py
@@ -4,9 +4,12 @@ from pathlib import Path
 
 def validate_dir_missing(ctx, param, value):
     """ click validator to ensure that artifacts directory does not exist """
+    assert ctx or param  # For linting
+
     path = Path(value)
 
-    if path.exists():
-        raise click.BadParameter(message="Artifacts directory {} already exists.".format(value))
+    if path.exists() or path.is_symlink():
+        raise click.BadParameter(
+            message="Artifacts location '{}' already exists.".format(value))
 
     return path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click==6.7
+click==7.0
 cryptography==2.3.1
 setuptools==18.2
 pytest==3.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click==7.0
 cryptography==2.3.1
 setuptools==18.2
-pytest==3.2.2
+pytest==4.5.0

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
     description='Exhibitor TLS artifact generation script',
     long_description=LONG_DESCRIPTION,
     install_requires=INSTALL_REQUIRES,
-    author='Rubin Deliallisi',
-    author_email="rdeliallisi@mesosphere.com",
+    author='Mesosphere Inc.',
+    author_email="security@mesosphere.com",
     url="https://mesosphere.com",
     keywords='exhibitor tls artifact mesosphere',
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.1'
+VERSION = '0.2'
 
 with open('requirements.txt') as requirements:
     INSTALL_REQUIRES = []

--- a/tests/test_gen_artifacts.py
+++ b/tests/test_gen_artifacts.py
@@ -1,0 +1,83 @@
+import stat
+from pathlib import Path
+
+import click
+import click.testing
+
+
+from exhibitor_tls_artifacts.gen_artifacts import app
+
+
+class TestCLI:
+    @staticmethod
+    def _validate_files(directory):
+        """ Ensures that artifacts are created and that they have the
+        appropriate permission """
+        files = [
+            ('client-cert.pem', 0o100644),
+            ('client-key.pem', 0o100600),
+            ('clientstore.jks', 0o100600),
+            ('root-cert.pem', 0o100644),
+            ('serverstore.jks', 0o100600),
+            ('truststore.jks', 0o100600)
+        ]
+        for f, mode in files:
+            full_path = directory / f
+            assert full_path.exists()
+            assert full_path.stat()[stat.ST_MODE] == mode
+
+    def test_default(self):
+        """ Tests the most basic operation """
+        runner = click.testing.CliRunner()
+
+        with runner.isolated_filesystem() as temp:
+            temp_path = Path(temp)
+            result = runner.invoke(
+                app, args=['10.10.10.10'], catch_exceptions=False)
+
+            assert result.exit_code == 0
+            artifact_path = temp_path / 'artifacts' / 'node_10_10_10_10'
+            assert artifact_path.exists()
+            self._validate_files(artifact_path)
+
+    def test_custom_dir(self, tmp_path):
+        """ Test outputting artifacts to a customer location """
+        runner = click.testing.CliRunner()
+        new_path = tmp_path / 'new'
+        result = runner.invoke(
+            app, args=['-d', new_path, '10.10.10.10'], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        self._validate_files(new_path / 'node_10_10_10_10')
+
+    def test_dir_exists(self):
+        """ Test error case when the output directory already exists """
+        runner = click.testing.CliRunner()
+
+        with runner.isolated_filesystem() as temp:
+            err = "Artifacts directory cannot exist!"
+            temp_path = Path(temp)
+            output_dir = temp_path / 'exists'
+            output_dir.mkdir()
+            result = runner.invoke(
+                app, args=['-d', output_dir, '10.10.10.10'], catch_exceptions=False)
+            assert result.exit_code == 2
+            assert err in result.stdout
+
+    def test_no_nodes(self):
+        """ Test error case if no arguments are provided """
+        err = "No nodes have been provided."
+        runner = click.testing.CliRunner()
+        result = runner.invoke(app, catch_exceptions=False)
+        assert result.exit_code == 2
+        assert err in result.stdout
+
+    def test_help(self):
+        """ Tests if there are any changes to the help output. This
+        is only useful for coercing a developer to write CLI tests if
+        an option/argument is added. """
+        help_bytes = 435
+        runner = click.testing.CliRunner()
+        result = runner.invoke(app, args=['--help'])
+        assert len(result.stdout_bytes) == help_bytes
+

--- a/tests/test_gen_artifacts.py
+++ b/tests/test_gen_artifacts.py
@@ -1,26 +1,22 @@
 import stat
+import textwrap
 from pathlib import Path
 
 import click
 import click.testing
 
-
 from exhibitor_tls_artifacts.gen_artifacts import app
 
 
 class TestCLI:
+
     @staticmethod
     def _validate_files(directory):
         """ Ensures that artifacts are created and that they have the
         appropriate permission """
-        files = [
-            ('client-cert.pem', 0o100644),
-            ('client-key.pem', 0o100600),
-            ('clientstore.jks', 0o100600),
-            ('root-cert.pem', 0o100644),
-            ('serverstore.jks', 0o100600),
-            ('truststore.jks', 0o100600)
-        ]
+        files = [('client-cert.pem', 0o100644), ('client-key.pem', 0o100600),
+                 ('clientstore.jks', 0o100600), ('root-cert.pem', 0o100644),
+                 ('serverstore.jks', 0o100600), ('truststore.jks', 0o100600)]
         for f, mode in files:
             full_path = directory / f
             assert full_path.exists()
@@ -32,8 +28,9 @@ class TestCLI:
 
         with runner.isolated_filesystem() as temp:
             temp_path = Path(temp)
-            result = runner.invoke(
-                app, args=['10.10.10.10'], catch_exceptions=False)
+            result = runner.invoke(app,
+                                   args=['10.10.10.10'],
+                                   catch_exceptions=False)
 
             assert result.exit_code == 0
             artifact_path = temp_path / 'artifacts' / 'node_10_10_10_10'
@@ -44,8 +41,9 @@ class TestCLI:
         """ Test outputting artifacts to a customer location """
         runner = click.testing.CliRunner()
         new_path = tmp_path / 'new'
-        result = runner.invoke(
-            app, args=['-d', new_path, '10.10.10.10'], catch_exceptions=False)
+        result = runner.invoke(app,
+                               args=['-d', new_path, '10.10.10.10'],
+                               catch_exceptions=False)
 
         assert result.exit_code == 0
         self._validate_files(new_path / 'node_10_10_10_10')
@@ -55,29 +53,49 @@ class TestCLI:
         runner = click.testing.CliRunner()
 
         with runner.isolated_filesystem() as temp:
-            err = "Artifacts directory cannot exist!"
+            err = textwrap.dedent("""\
+            Usage: exhibitor-tls-artifacts [OPTIONS] [NODES]...
+
+            Error: Invalid value for "-d" / "--output-directory": Artifacts directory cannot exist!
+            """)
             temp_path = Path(temp)
             output_dir = temp_path / 'exists'
             output_dir.mkdir()
-            result = runner.invoke(
-                app, args=['-d', output_dir, '10.10.10.10'], catch_exceptions=False)
+            result = runner.invoke(app,
+                                   args=['-d', output_dir, '10.10.10.10'],
+                                   catch_exceptions=False)
             assert result.exit_code == 2
-            assert err in result.stdout
+            assert err == result.stdout
 
     def test_no_nodes(self):
         """ Test error case if no arguments are provided """
-        err = "No nodes have been provided."
+        err = textwrap.dedent("""\
+        Usage: exhibitor-tls-artifacts [OPTIONS] [NODES]...
+
+        Error: Invalid value for "-d" / "--output-directory": Artifacts directory cannot exist!
+        """)
         runner = click.testing.CliRunner()
         result = runner.invoke(app, catch_exceptions=False)
         assert result.exit_code == 2
+        print(result.stdout)
         assert err in result.stdout
 
     def test_help(self):
         """ Tests if there are any changes to the help output. This
         is only useful for coercing a developer to write CLI tests if
         an option/argument is added. """
-        help_bytes = 435
+        expected_help = textwrap.dedent("""\
+            Usage: exhibitor-tls-artifacts [OPTIONS] [NODES]...
+
+              Generates Admin Router and Exhibitor TLS artifacts. NODES should consist of
+              a space separated list of master ip addresses. See
+              https://docs.mesosphere.com/1.13/security/ent/tls-ssl/exhibitor-tls/
+
+            Options:
+              -d, --output-directory TEXT  Directory to put artifacts in. This
+                                           output_directory must not exist.
+              --help                       Show this message and exit.
+            """)
         runner = click.testing.CliRunner()
         result = runner.invoke(app, args=['--help'])
-        assert len(result.stdout_bytes) == help_bytes
-
+        assert expected_help == result.stdout


### PR DESCRIPTION
# Overview

In order to support mutual TLS on a static multi-node Exhibitor ensemble, client certificates must be generated for each master and be signed by a globally unique CA. This PR  adds support for generating the root CA and an arbitrary number of client/server keys and certificates for use by AdminRouter and Exhibitor. 



# Usage
```bash
Usage: exhibitor-tls-artifacts [OPTIONS] [NODES]...

  Generates Admin Router and Exhibitor TLS artifacts. NODES should consist
  of a space seperated list of master ip addresses. See
  https://docs.mesosphere.com/1.13/security/ent/tls-ssl/exhibitor-tls/

Options:
  -d, --dir TEXT  Directory to put artifacts in.
  --help          Show this message and exit.
```


# Example
```
$ docker run -it -v $(pwd):/src arch-java exhibitor-tls-artifacts 172.16.0.2 172.16.0.3 172.16.0.4 -d /src/artifacts/
$ tree artifacts/
artifacts/
├── node_172_16_0_2
│   ├── client-cert.pem
│   ├── client-key.pem
│   ├── clientstore.jks
│   ├── root-cert.pem
│   ├── serverstore.jks
│   └── truststore.jks
├── node_172_16_0_3
│   ├── client-cert.pem
│   ├── client-key.pem
│   ├── clientstore.jks
│   ├── root-cert.pem
│   ├── serverstore.jks
│   └── truststore.jks
├── node_172_16_0_4
│   ├── client-cert.pem
│   ├── client-key.pem
│   ├── clientstore.jks
│   ├── root-cert.pem
│   ├── serverstore.jks
│   └── truststore.jks
├── root-cert.pem
└── truststore.jks

3 directories, 20 files
```