### PR TITLE
Allow user to specify base artifact directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For convenience, a bash script can be downloaded from the GitHub release page an
 ```sh
 curl -O https://github.com/mesosphere/exhibitor-tls-artifacts-gen/releases/latest/download/exhibitor-tls-artifacts
 chmod +x exhibitor-tls-artifacts
-./exhibitor-tls-artifacts -- --help
+./exhibitor-tls-artifacts --help
 ```
 
 There is a limitation when using the `exhibitor-tls-artifacts` bash script.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ that can pick up these artifacts and talk to the ensemble.
 * [Tests](#tests)
 
 ## System Requirements
-
-1) `Java 8` must be installed.
-2) `OpenSSL 1.x.y` must be installed.
+1) `Python 3.5+` must be installed.
+2) `Java 8` must be installed.
+3) `OpenSSL 1.x.y` must be installed.
 
 ## Installation
 
@@ -51,13 +51,12 @@ dependencies with docker:
 docker run -it --rm -v $(pwd):/build --workdir /build mesosphere/exhibitor-tls-artifacts-gen --help
 ```
 
-For a convenience there is a bash  script that can be downloaded from
-GitHub release pages and invoked directly.
+For convenience, a bash script can be downloaded from the GitHub release page and invoked directly.
 
 ```sh
 curl -O https://github.com/mesosphere/exhibitor-tls-artifacts-gen/releases/latest/download/exhibitor-tls-artifacts
 chmod +x exhibitor-tls-artifacts
-./exhibitor-tls-artifacts --help
+./exhibitor-tls-artifacts -- --help
 ```
 
 There is a limitation when using the `exhibitor-tls-artifacts` bash script.
@@ -65,6 +64,42 @@ The output of running this script is a directory that contains TLS artifacts (ce
 The script mounts current working directory the container with the script.
 Only paths relative to the current working directory can be used as `--output-directory`.
 Using absolute path will result in artifacts being generated in the container and destroyed when container exits.
+
+If it is necessary to store the artifacts in a directory other than the current working directory
+the bash script can take an extra parameter  `-b, --bind-directory`. For example:
+
+```
+$ ./exhibitor-tls-artifacts -b /tmp 192.168.0.1 192.168.0.2 192.168.0.3
+
+$ sudo tree /tmp/artifacts/
+/tmp/artifacts/
+├── node_192_168_0_1
+│   ├── client-cert.pem
+│   ├── client-key.pem
+│   ├── clientstore.jks
+│   ├── root-cert.pem
+│   ├── serverstore.jks
+│   └── truststore.jks
+├── node_192_168_0_2
+│   ├── client-cert.pem
+│   ├── client-key.pem
+│   ├── clientstore.jks
+│   ├── root-cert.pem
+│   ├── serverstore.jks
+│   └── truststore.jks
+├── node_192_168_0_3
+│   ├── client-cert.pem
+│   ├── client-key.pem
+│   ├── clientstore.jks
+│   ├── root-cert.pem
+│   ├── serverstore.jks
+│   └── truststore.jks
+├── root-cert.pem
+└── truststore.jks
+
+3 directories, 20 files
+
+```
 
 ## Script Usage
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ that can pick up these artifacts and talk to the ensemble.
 * [Tests](#tests)
 
 ## System Requirements
-1) `Python 3.5+` must be installed.
+1) `Python 3.6` must be installed.
 2) `Java 8` must be installed.
 3) `OpenSSL 1.x.y` must be installed.
 

--- a/build/exhibitor-tls-artifacts.tpl
+++ b/build/exhibitor-tls-artifacts.tpl
@@ -11,14 +11,6 @@ while (( "$#" )); do
       BIND_DIRECTORY=$2
       shift 2
       ;;
-    --) # end argument parsing
-      shift
-      break
-      ;;
-    -*|--*=) # unsupported flags
-      echo "Error: Unsupported flag $1" >&2
-      exit 1
-      ;;
     *) # preserve positional arguments
       PARAMS="$PARAMS $1"
       shift

--- a/build/exhibitor-tls-artifacts.tpl
+++ b/build/exhibitor-tls-artifacts.tpl
@@ -3,12 +3,12 @@
 set -e
 
 PARAMS=""
-OUTPUT_DIRECTORY="$(pwd)"
+BIND_DIRECTORY="$(pwd)"
 
 while (( "$#" )); do
   case "$1" in
-    -d|--directory)
-      OUTPUT_DIRECTORY=$2
+    -b|--bind-directory)
+      BIND_DIRECTORY=$2
       shift 2
       ;;
     --) # end argument parsing
@@ -28,4 +28,10 @@ done
 
 eval set -- "$PARAMS"
 
-docker run -it --rm -v ${OUTPUT_DIRECTORY}:/build --workdir=/build {{DOCKER_IMAGE}} ${PARAMS}
+# Note BIND_DIRECTORY in this context translates to the bind mount
+# created in the container. It DOES not carry over to -d argument of
+# the artifacts script. For instance, if this script is invoked with
+# `exhibitor-tls-artifacts -d /tmp 10.0.0.1 10.0.0.2`, then the
+# resulting output directory would be `/tmp/artifacts`
+
+docker run -it --rm -v ${BIND_DIRECTORY}:/build --workdir=/build {{DOCKER_IMAGE}} ${PARAMS}

--- a/build/exhibitor-tls-artifacts.tpl
+++ b/build/exhibitor-tls-artifacts.tpl
@@ -1,5 +1,31 @@
 #!/usr/bin/env bash
 
-# set -ex
+set -e
 
-docker run -it --rm -v $(pwd):/build --workdir /build {{DOCKER_IMAGE}} $@
+PARAMS=""
+OUTPUT_DIRECTORY="$(pwd)"
+
+while (( "$#" )); do
+  case "$1" in
+    -d|--directory)
+      OUTPUT_DIRECTORY=$2
+      shift 2
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      shift
+      ;;
+  esac
+done
+
+eval set -- "$PARAMS"
+
+docker run -it --rm -v ${OUTPUT_DIRECTORY}:/build --workdir=/build {{DOCKER_IMAGE}} ${PARAMS}

--- a/exhibitor_tls_artifacts/gen_certificates.py
+++ b/exhibitor_tls_artifacts/gen_certificates.py
@@ -38,7 +38,7 @@ class CertificateGenerator:
         return cert
 
     def __store_cert(self, cert, cert_path):
-        cert_path.parent.mkdir(mode=0o700, exist_ok=True)
+        cert_path.parent.mkdir(mode=0o755, exist_ok=True)
         with open(cert_path, 'wb') as f:
             f.write(cert.public_bytes(serialization.Encoding.PEM))
 
@@ -52,7 +52,7 @@ class CertificateGenerator:
         return key
 
     def __store_key(self, key, key_path, password=None):
-        key_path.parent.mkdir(mode=0o700, exist_ok=True)
+        key_path.parent.mkdir(mode=0o755, exist_ok=True)
         if password is None:
             encryption = serialization.NoEncryption()
         else:


### PR DESCRIPTION
# Changes

1) Modifies the bash script template so that it accepts the `-b`, `--bind-address` argument. This is helpful in scenarios such as E2E testing where a temporary directory is used for artifacts.
2) Relaxes permissions on the artifacts directory to satisfy a world readable requirement on the target.

